### PR TITLE
chore: run rotation job only on weekdays

### DIFF
--- a/database/put-rotation.test.ts
+++ b/database/put-rotation.test.ts
@@ -29,7 +29,7 @@ it("should insert item into table", async () => {
   const { Item } = await ddb.send(
     new GetCommand({
       TableName: process.env.ROTATIONS_TABLE,
-      Key: { id },
+      Key: { id, next_rotation_at },
     })
   );
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -60,7 +60,7 @@ functions:
   executeRotation:
     handler: handlers/execute-rotations.handler
     events:
-      - schedule: cron(0 12 * * ? *)
+      - schedule: cron(0 12 ? * MON-FRI *)
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,13 +71,13 @@ resources:
         AttributeDefinitions:
           - AttributeName: id
             AttributeType: S
-          # - AttributeName: next_rotation_at
-          #   AttributeType: S
+          - AttributeName: next_rotation_at
+            AttributeType: S
         KeySchema:
           - AttributeName: id
             KeyType: HASH
-          # - AttributeName: next_rotation_at
-          #   KeyType: RANGE
+          - AttributeName: next_rotation_at
+            KeyType: RANGE
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1


### PR DESCRIPTION
This PR changes the cron expression for the `executeRotation` function so that it only runs on weekdays from now on.